### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, labeled]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   automerge:
     if: github.actor == 'dependabot[bot]'


### PR DESCRIPTION
Potential fix for [https://github.com/AdityaSreevatsaK/100DaysOfCode_Python/security/code-scanning/7](https://github.com/AdityaSreevatsaK/100DaysOfCode_Python/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. The workflow uses the `GITHUB_TOKEN` to add labels and enable auto-merge, which requires `contents: read` and `pull-requests: write`. These permissions will be explicitly set in the `permissions` block. This ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
