### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dummy-check.yml
+++ b/.github/workflows/dummy-check.yml
@@ -3,6 +3,9 @@ name: Dummy Check
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   dummy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AdityaSreevatsaK/100DaysOfCode_Python/security/code-scanning/9](https://github.com/AdityaSreevatsaK/100DaysOfCode_Python/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only performs a dummy status check and does not interact with the repository, we will set the permissions to `contents: read`, which is the minimal permission required for most workflows. This ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
